### PR TITLE
Improved assembler and signature scanner error reporting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CommonLoader/externals/fmt"]
+	path = CommonLoader/externals/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CommonLoader/AssemblerService.cpp
+++ b/CommonLoader/AssemblerService.cpp
@@ -1,5 +1,7 @@
 #include "AssemblerService.h"
 #include "AssemblerService_In.h"
+#include "Logger.h"
+#include <sstream>
 
 using namespace CommonLoader;
 
@@ -47,12 +49,44 @@ AssemblerResult* AssemblerService::CompileAssembly(const char* source, uint64_t 
 {
 	AssemblerResult* result = new AssemblerResult();
 
-	if (ks_asm(AssemblerServiceImpl::assembler_instance, source, base, &result->data, &result->length, &result->instruction_count) == -1)
-	{
-		result->error_string = ks_strerror(ks_errno(AssemblerServiceImpl::assembler_instance));
-	}
+	ks_asm(AssemblerServiceImpl::assembler_instance, source, base,
+		&result->data, &result->length, &result->instruction_count,
+		(ks_err_context**)&result->errors, &result->errors_size);
 
 	return result;
+}
+
+void AssemblerService::OnError(const char* message, const AssemblerResult* result)
+{
+	if (!result->errors_size)
+	{
+		return;
+	}
+
+	ApplicationStore::SetState(CMN_LOADER_STATE_INIT_ASSEMBLY_FAILED, 1);
+
+	if (ApplicationStore::GetState(CMN_LOADER_STATE_DISABLE_LOGGING))
+	{
+		return;
+	}
+
+	if (message)
+	{
+		Logger::Error("{}", message);
+	}
+
+	for (size_t i = 0; i < result->errors_size; i++)
+	{
+		const AssemblerError& err = result->errors[i];
+
+		Logger::Error("{}({},{}): error {}: '{}': {}",
+			message ? "    " : "",
+			err.line_num,
+			err.line_char,
+			err.err_num,
+			err.line,
+			ks_strerror((ks_err)err.err_num));
+	}
 }
 
 bool AssemblerServiceImpl::ResolveSymbol(const char* symbol, uint64_t* value)
@@ -70,8 +104,13 @@ bool AssemblerServiceImpl::ResolveSymbol(const char* symbol, uint64_t* value)
 
 AssemblerResult::~AssemblerResult()
 {
-	if (data != nullptr)
+	if (data)
 	{
 		ks_free(data);
+	}
+
+	if (errors)
+	{
+		delete errors;
 	}
 }

--- a/CommonLoader/AssemblerService.h
+++ b/CommonLoader/AssemblerService.h
@@ -15,5 +15,6 @@ namespace CommonLoader
 		static void SetSymbol(const char* name, uint64_t value);
 		static bool GetSymbol(const char* name, uint64_t& value);
 		static AssemblerResult* CompileAssembly(const char* source, uint64_t base = 0);
+		static void OnError(const char* message, const AssemblerResult* result);
 	};
 }

--- a/CommonLoader/AssemblyLoader.h
+++ b/CommonLoader/AssemblyLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CodeObject.h"
+#include "Logger.h"
 #include "MemoryProvider.h"
 
 using namespace System;
@@ -64,6 +65,8 @@ namespace CommonLoader
 		{
 			for each (CodeObject ^ code in codes)
 			{
+				Logger::Info("Loading Code: {}", code->Name);
+
 				code->Init();
 			}
 		}

--- a/CommonLoader/AssemblyLoader.h
+++ b/CommonLoader/AssemblyLoader.h
@@ -65,7 +65,10 @@ namespace CommonLoader
 		{
 			for each (CodeObject ^ code in codes)
 			{
-				Logger::Info("Loading Code: {}", code->Name);
+				if (code->Name)
+				{
+					Logger::Info("Loading Code: {}", *code->Name);
+				}
 
 				code->Init();
 			}

--- a/CommonLoader/CodeObject.h
+++ b/CommonLoader/CodeObject.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <msclr/marshal_cppstd.h>
+
 using namespace System;
 using namespace System::Reflection;
 using namespace System::Runtime::InteropServices;
+using namespace msclr::interop;
 
 namespace CommonLoader 
 {
@@ -15,7 +18,7 @@ namespace CommonLoader
 		Action^ frameMethod;
 
 	public:
-		const char* Name;
+		std::string* Name;
 
 		CodeObject(Type^ base) 
 		{
@@ -23,20 +26,9 @@ namespace CommonLoader
 			baseObject = Activator::CreateInstance(base);
 
 			// TODO: add managed fields for name, category and ID.
-			Name = (const char*)Marshal::StringToHGlobalAnsi(base->Name).ToPointer();
-
-			// Omit hash suffix from reflected name.
-			char* c = (char*)Name;
-			while (c && *c != '\0')
-			{
-				if (*c == '_')
-				{
-					*c = '\0';
-					break;
-				}
-
-				c++;
-			}
+			Name = new std::string();
+			*Name = marshal_as<std::string>(base->Name);
+			*Name = Name->substr(0, Name->find('_'));
 
 			MethodInfo^ init = baseType->GetMethod("Init");
 			MethodInfo^ onFrame = baseType->GetMethod("OnFrame");
@@ -50,8 +42,16 @@ namespace CommonLoader
 
 		~CodeObject()
 		{
+			this->!CodeObject();
+		}
+
+		!CodeObject()
+		{
 			if (Name)
-				Marshal::FreeHGlobal((IntPtr)(void*)Name);
+			{
+				delete Name;
+				Name = nullptr;
+			}
 		}
 
 		void Init() 

--- a/CommonLoader/CodeObject.h
+++ b/CommonLoader/CodeObject.h
@@ -2,6 +2,7 @@
 
 using namespace System;
 using namespace System::Reflection;
+using namespace System::Runtime::InteropServices;
 
 namespace CommonLoader 
 {
@@ -14,10 +15,29 @@ namespace CommonLoader
 		Action^ frameMethod;
 
 	public:
+		const char* Name;
+
 		CodeObject(Type^ base) 
 		{
 			baseType = base;
 			baseObject = Activator::CreateInstance(base);
+
+			// TODO: add managed fields for name, category and ID.
+			Name = (const char*)Marshal::StringToHGlobalAnsi(base->Name).ToPointer();
+
+			// Omit hash suffix from reflected name.
+			char* c = (char*)Name;
+			while (c && *c != '\0')
+			{
+				if (*c == '_')
+				{
+					*c = '\0';
+					break;
+				}
+
+				c++;
+			}
+
 			MethodInfo^ init = baseType->GetMethod("Init");
 			MethodInfo^ onFrame = baseType->GetMethod("OnFrame");
 
@@ -26,6 +46,12 @@ namespace CommonLoader
 			
 			if (onFrame)
 				frameMethod = safe_cast<Action^>(Delegate::CreateDelegate(Action::typeid, baseObject, onFrame));
+		}
+
+		~CodeObject()
+		{
+			if (Name)
+				Marshal::FreeHGlobal((IntPtr)(void*)Name);
 		}
 
 		void Init() 

--- a/CommonLoader/CommonLoader.cpp
+++ b/CommonLoader/CommonLoader.cpp
@@ -1,5 +1,7 @@
 #include "CommonLoader.h"
+#include "Logger.h"
 #include "ManagedCommonLoader.h"
+#include <sstream>
 
 #pragma unmanaged
 bool is_init{};
@@ -26,6 +28,41 @@ bool CommonLoader::LoadAssembly(const char* path)
 void CommonLoader::RaiseInitializers()
 {
 	ManagedCommonLoader::RaiseInitializers();
+
+	bool sigFailed = ApplicationStore::GetState(CMN_LOADER_STATE_INIT_SIG_SCAN_FAILED);
+	bool asmFailed = ApplicationStore::GetState(CMN_LOADER_STATE_INIT_ASSEMBLY_FAILED);
+	bool errored = sigFailed || asmFailed;
+
+	if (errored)
+	{
+		std::stringstream errStream{};
+
+		if (sigFailed && asmFailed)
+		{
+			errStream << "One or more critical errors occurred upon initialisation.";
+		}
+		else if (sigFailed)
+		{
+			errStream << "Failed to find signatures.";
+		}
+		else if (asmFailed)
+		{
+			errStream << "Failed to compile assembly in one or more codes.";
+		}
+
+		errStream << std::endl << std::endl
+			<< "This may lead to unstable behaviour and could potentially result in a game crash."
+			<< std::endl << std::endl
+			<< "Would you like to continue anyway?";
+
+		int msgResult = MessageBoxA(nullptr, errStream.str().c_str(),
+			"Error", MB_YESNO | MB_ICONERROR | MB_DEFBUTTON2);
+
+		if (msgResult == IDNO)
+		{
+			exit(-1);
+		}
+	}
 }
 
 void CommonLoader::RaiseUpdates()

--- a/CommonLoader/CommonLoader.vcxproj
+++ b/CommonLoader/CommonLoader.vcxproj
@@ -97,6 +97,8 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedIncludeFiles>pch.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)externals\fmt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -118,6 +120,8 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedIncludeFiles>pch.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)externals\fmt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -141,6 +145,8 @@
       <PreprocessorDefinitions>WIN64;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedIncludeFiles>pch.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)externals\fmt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -163,6 +169,8 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <ForcedIncludeFiles>pch.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)externals\fmt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -185,6 +193,7 @@
     <ClInclude Include="CommonLoader.h" />
     <ClInclude Include="CommonLoaderAPI.h" />
     <ClInclude Include="HookService.h" />
+    <ClInclude Include="Logger.h" />
     <ClInclude Include="ManagedCommonLoader.h" />
     <ClInclude Include="MemoryProvider.h" />
     <ClInclude Include="pch.h" />

--- a/CommonLoader/CommonLoader.vcxproj.filters
+++ b/CommonLoader/CommonLoader.vcxproj.filters
@@ -20,6 +20,7 @@
     <ClInclude Include="Resource.h" />
     <ClInclude Include="SigScanner.h" />
     <ClInclude Include="CommonLoaderAPI.h" />
+    <ClInclude Include="Logger.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ApplicationStore.cpp" />

--- a/CommonLoader/CommonLoaderAPI.h
+++ b/CommonLoader/CommonLoaderAPI.h
@@ -11,17 +11,29 @@
 #endif
 
 #define CMN_LOADER_STATE_SKIP_SIG_VALIDATION 0
-#define CMN_LOADER_STATE_MAX 1
+#define CMN_LOADER_STATE_INIT_SIG_SCAN_FAILED 1
+#define CMN_LOADER_STATE_INIT_ASSEMBLY_FAILED 2
+#define CMN_LOADER_STATE_DISABLE_LOGGING 3
+#define CMN_LOADER_STATE_MAX 4
 #define CMN_LOADER_STATE_INVALID -1
 
 #define DECLARE_API_FUNC(RETURN_TYPE, NAME, ...) RETURN_TYPE (CMN_LOADER_API *NAME)(__VA_ARGS__) = nullptr;
+
+struct AssemblerError
+{
+	size_t line_num{};
+	size_t line_char{};
+	unsigned int err_num{};
+	char line[256]{};
+};
 
 struct AssemblerResult
 {
 	size_t instruction_count{};
 	size_t length{};
 	unsigned char* data{};
-	const char* error_string{};
+	AssemblerError* errors{};
+	size_t errors_size{};
 
 	// Private data
 #ifdef CMN_LOADER_IMPL

--- a/CommonLoader/HookService.cpp
+++ b/CommonLoader/HookService.cpp
@@ -27,16 +27,9 @@ bool CommonLoader::HookService::WriteASMHook(const char* source, size_t address,
 	cs_free(insn, count);
 
 	std::unique_ptr<AssemblerResult> compiled_code{ AssemblerService::CompileAssembly(source, reinterpret_cast<uint64_t>(ApplicationStore::GetModule().base)) };
-	if (compiled_code->error_string)
-	{
-		std::stringstream err_stream{};
-		err_stream << "Failed to compile assembly:" << std::endl;
-		err_stream << "\t" << compiled_code->error_string << std::endl;
-		err_stream << "\tNear instruction " << compiled_code->instruction_count << std::endl;
 
-		MessageBoxA(nullptr, err_stream.str().c_str(), "Error", MB_OK | MB_ICONERROR);
-		return false;
-	}
+	if (compiled_code->errors_size)
+		AssemblerService::OnError(fmt::format("Error assembling statements in hook at 0x{:08X}.", address).c_str(), compiled_code.get());
 
 	void* hookPtr = _aligned_malloc(compiled_code->length + hookLen + MIN_HOOK_LENGTH, alignof(void*));
 	size_t pos = reinterpret_cast<size_t>(hookPtr);

--- a/CommonLoader/Logger.h
+++ b/CommonLoader/Logger.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "ApplicationStore.h"
+#include "CommonLoaderAPI.h"
+#include <string>
+
+#define FOREGROUND_WHITE  (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE)
+#define FOREGROUND_YELLOW (FOREGROUND_RED | FOREGROUND_GREEN)
+
+namespace Logger
+{
+    enum class LogType
+    {
+        Info,
+        Debug,
+        Warning,
+        Error
+    };
+
+    inline static HANDLE g_hStdOut{};
+
+    template<class ... Args>
+    static void Log(const std::string_view text, LogType type, Args... format)
+    {
+        if (!GetConsoleWindow() || CommonLoader::ApplicationStore::GetState(CMN_LOADER_STATE_DISABLE_LOGGING))
+            return;
+
+        if (!g_hStdOut)
+            g_hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+
+        std::string prefix = "[INFO] ";
+
+        switch (type)
+        {
+            case LogType::Debug:
+                prefix = "[DEBUG]";
+                SetConsoleTextAttribute(g_hStdOut, FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+                break;
+
+            case LogType::Warning:
+                prefix = "[WARN] ";
+                SetConsoleTextAttribute(g_hStdOut, FOREGROUND_YELLOW | FOREGROUND_INTENSITY);
+                break;
+
+            case LogType::Error:
+                prefix = "[ERROR]";
+                SetConsoleTextAttribute(g_hStdOut, FOREGROUND_RED | FOREGROUND_INTENSITY);
+                break;
+
+            default:
+                SetConsoleTextAttribute(g_hStdOut, FOREGROUND_WHITE);
+                break;
+        }
+
+        fmt::println("[CL] {} {}", prefix, fmt::format(text, format...));
+
+        SetConsoleTextAttribute(g_hStdOut, FOREGROUND_WHITE);
+    }
+
+    template<class ... Args>
+    static void Info(const std::string_view text, Args... format)
+    {
+        Log(text, LogType::Info, format...);
+    }
+
+    template<class ... Args>
+    static void Debug(const std::string_view text, Args... format)
+    {
+        Log(text, LogType::Debug, format...);
+    }
+
+    template<class ... Args>
+    static void Warning(const std::string_view text, Args... format)
+    {
+        Log(text, LogType::Warning, format...);
+    }
+
+    template<class ... Args>
+    static void Error(const std::string_view text, Args... format)
+    {
+        Log(text, LogType::Error, format...);
+    }
+}

--- a/CommonLoader/MemoryProvider.h
+++ b/CommonLoader/MemoryProvider.h
@@ -113,6 +113,9 @@ namespace CommonLoader
 		{
 			const ManagedStringANSI source{ instructions };
 			const AssemblerResult* result = AssemblerService::CompileAssembly(source);
+
+			if (result->errors_size)
+				AssemblerService::OnError("Error assembling statements.", result);
 			
 			array<Byte>^ bytes = gcnew array<Byte>(result->length);
 			pin_ptr<Byte> ptr = &bytes[0];

--- a/CommonLoader/SigScanner.cpp
+++ b/CommonLoader/SigScanner.cpp
@@ -3,6 +3,9 @@
 #include "SigScanner.h"
 #include "ApplicationStore.h"
 #include "CommonLoaderAPI.h"
+#include "Logger.h"
+#include <iomanip>
+#include <sstream>
 #include <unordered_map>
 
 constexpr const char* ScannerSection = "SigScanner";
@@ -45,6 +48,26 @@ void MakePatternHash(const char* p_pattern, const char* p_mask, size_t pattern_l
 bool SearchSignatureCache(const SignatureKey& key, void* p_begin, size_t size, void*& out);
 void CommitSignatureCache(const SignatureKey& key, void* p_memory);
 
+static std::string FormatSignature(const char* p_pattern, const char* p_mask)
+{
+    std::stringstream result{};
+    const size_t length = strlen(p_mask);
+
+    result << '\"';
+
+    for (size_t i = 0; i < length; i++)
+    {
+        uint32_t b = *(uint8_t*)((size_t)p_pattern + i);
+
+        result << "\\x" << std::uppercase << std::hex
+               << std::setw(2) << std::setfill('0') << b;
+    }
+
+    result << "\", \"" << p_mask << '\"';
+
+    return result.str();
+}
+
 void CommonLoader::InitSigScanner()
 {
     std::vector<std::pair<const char*, const char*>> values{};
@@ -83,16 +106,27 @@ void* CommonLoader::Scan(const char* p_pattern, const char* p_mask, size_t patte
 	void* cachedResult{};
     if (SearchSignatureCache(key, p_begin, size, cachedResult))
     {
-        return ApplicationStore::GetState(CMN_LOADER_STATE_SKIP_SIG_VALIDATION) ? cachedResult :
-    		ScanUncached(p_pattern, p_mask, pattern_length, cachedResult, pattern_length);
+        // When scanning uncached for validation, error reporting is disabled
+        // for signatures that fail to scan.
+        // 
+        // This is done so that multiple codes using the same signature won't
+        // result in a critical warning should one of the codes write something
+        // to the signature location, causing the rest to fail.
+        //
+        // We've retrieved the signature address from the cache, so at least
+        // one scan has succeeded.
+        return ApplicationStore::GetState(CMN_LOADER_STATE_SKIP_SIG_VALIDATION)
+            ? cachedResult
+            : ScanUncached(p_pattern, p_mask, pattern_length, cachedResult, pattern_length, false);
     }
     
     void* address = ScanUncached(p_pattern, p_mask, pattern_length, p_begin, size);
 	CommitSignatureCache(key, address);
+
     return address;
 }
 
-void* CommonLoader::ScanUncached(const char* p_pattern, const char* p_mask, size_t pattern_length, void* p_begin, size_t size)
+void* CommonLoader::ScanUncached(const char* p_pattern, const char* p_mask, size_t pattern_length, void* p_begin, size_t size, bool validate)
 {
     if (p_begin == nullptr)
     {
@@ -111,6 +145,16 @@ void* CommonLoader::ScanUncached(const char* p_pattern, const char* p_mask, size
 
         if (j == pattern_length)
             return memory;
+    }
+
+    if (validate)
+    {
+        ApplicationStore::SetState(CMN_LOADER_STATE_INIT_SIG_SCAN_FAILED, 1);
+
+        if (!ApplicationStore::GetState(CMN_LOADER_STATE_DISABLE_LOGGING))
+        {
+            Logger::Error("Signature scan failed: {}", FormatSignature(p_pattern, p_mask));
+        }
     }
 
     return nullptr;

--- a/CommonLoader/SigScanner.h
+++ b/CommonLoader/SigScanner.h
@@ -5,5 +5,5 @@ namespace CommonLoader
 	void InitSigScanner();
 	void* Scan(const char* p_pattern, const char* p_mask);
 	void* Scan(const char* p_pattern, const char* p_mask, size_t pattern_length, void* p_begin, size_t size);
-	void* ScanUncached(const char* p_pattern, const char* p_mask, size_t pattern_length, void* p_begin, size_t size);
+	void* ScanUncached(const char* p_pattern, const char* p_mask, size_t pattern_length, void* p_begin, size_t size, bool validate = true);
 }

--- a/CommonLoader/externals/keystone/llvm/include/llvm/MC/MCParser/AsmLexer.h
+++ b/CommonLoader/externals/keystone/llvm/include/llvm/MC/MCParser/AsmLexer.h
@@ -30,6 +30,7 @@ class AsmLexer : public MCAsmLexer {
   const char *CurPtr;
   StringRef CurBuf;
   bool isAtStartOfLine;
+  bool isDoubleEOSEmitter;
 
   void operator=(const AsmLexer&) = delete;
   AsmLexer(const AsmLexer&) = delete;
@@ -46,6 +47,7 @@ public:
 
   StringRef LexUntilEndOfStatement() override;
   StringRef LexUntilEndOfLine();
+  StringRef PeekUntilEndOfLine();
 
   size_t peekTokens(MutableArrayRef<AsmToken> Buf,
                     bool ShouldSkipSpace = true) override;

--- a/CommonLoader/externals/keystone/llvm/include/llvm/MC/MCParser/MCAsmParser.h
+++ b/CommonLoader/externals/keystone/llvm/include/llvm/MC/MCParser/MCAsmParser.h
@@ -10,6 +10,7 @@
 #ifndef LLVM_MC_MCPARSER_MCASMPARSER_H
 #define LLVM_MC_MCPARSER_MCASMPARSER_H
 
+#include "keystone/keystone.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCParser/AsmLexer.h"
@@ -106,7 +107,7 @@ public:
   virtual void setAssemblerDialect(unsigned i) { }
 
   /// \brief Run the parser on the input source buffer.
-  virtual size_t Run(bool NoInitialTextSection, uint64_t Address, bool NoFinalize = false) = 0;
+  virtual size_t Run(bool NoInitialTextSection, uint64_t Address, bool NoFinalize = false, std::vector<ks_err_context>* Errors = nullptr) = 0;
 
   virtual void setParsingInlineAsm(bool V) = 0;
   virtual bool isParsingInlineAsm() = 0;

--- a/CommonLoader/externals/keystone/llvm/keystone/ks.cpp
+++ b/CommonLoader/externals/keystone/llvm/keystone/ks.cpp
@@ -45,7 +45,8 @@ const char *ks_strerror(ks_err code)
 {
     switch(code) {
         default:
-            return "Unknow error";  // FIXME
+            return "Unknown error";  // FIXME
+                                     // FIX (Hyper): corrected typo "Unknow error".
         case KS_ERR_OK:
             return "OK (KS_ERR_OK)";
         case KS_ERR_NOMEM:
@@ -528,7 +529,9 @@ int ks_asm(ks_engine *ks,
         const char *assembly,
         uint64_t address,
         unsigned char **insn, size_t *insn_size,
-        size_t *stat_count)
+        size_t *stat_count,
+        ks_err_context **stat_errors,
+        size_t *stat_errors_size)
 {
     MCCodeEmitter *CE;
     MCStreamer *Streamer;
@@ -565,13 +568,31 @@ int ks_asm(ks_engine *ks,
 
     Parser->setTargetParser(*TAP);
 
-    // TODO: optimize this to avoid setting up NASM every time we call ks_asm()
-    if (ks->arch == KS_ARCH_X86 && ks->syntax == KS_OPT_SYNTAX_NASM) {
-        Parser->initializeDirectiveKindMap(KS_OPT_SYNTAX_NASM);
-        ks->MAI->setCommentString(";");
+    if (ks->arch == KS_ARCH_X86) {
+        // TODO: optimize this to avoid setting up NASM every time we call ks_asm()
+        if (ks->syntax == KS_OPT_SYNTAX_NASM) {
+            Parser->initializeDirectiveKindMap(KS_OPT_SYNTAX_NASM);
+        }
+
+        // FIX (Hyper): semi-colon is also used for Intel syntax.
+        if (ks->syntax == KS_OPT_SYNTAX_INTEL || ks->syntax == KS_OPT_SYNTAX_NASM) {
+            ks->MAI->setCommentString(";");
+        }
     }
 
-    *stat_count = Parser->Run(false, address);
+    std::vector<ks_err_context> parser_errors{};
+
+    *stat_count = Parser->Run(false, address, false, &parser_errors);
+
+    // EDIT (Hyper): implemented optional error results.
+    if (stat_errors && stat_errors_size && !parser_errors.empty()) {
+        *stat_errors_size = parser_errors.size();
+        *stat_errors = new ks_err_context[*stat_errors_size];
+
+        for (size_t i = 0; i < *stat_errors_size; i++) {
+            (*stat_errors)[i] = parser_errors[i];
+        }
+    }
 
     // PPC counts empty statement
     if (ks->arch == KS_ARCH_PPC)

--- a/CommonLoader/externals/keystone/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/CommonLoader/externals/keystone/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -442,6 +442,16 @@ StringRef AsmLexer::LexUntilEndOfLine() {
   return StringRef(TokStart, CurPtr-TokStart);
 }
 
+StringRef AsmLexer::PeekUntilEndOfLine() {
+  const char *SavedCurPtr = CurPtr;
+
+  while (*SavedCurPtr != '\n' && *SavedCurPtr != '\r' &&
+         (*SavedCurPtr != 0 || SavedCurPtr != CurBuf.end())) {
+    ++SavedCurPtr;
+  }
+  return StringRef(TokStart, SavedCurPtr-TokStart);
+}
+
 size_t AsmLexer::peekTokens(MutableArrayRef<AsmToken> Buf,
                             bool ShouldSkipSpace)
 {
@@ -496,6 +506,21 @@ bool AsmLexer::isAtStatementSeparator(const char *Ptr) {
 AsmToken AsmLexer::LexToken()
 {
   TokStart = CurPtr;
+
+  // EDIT (Hyper): emit two EndOfStatement tokens for single '\n' use.
+  // 
+  // This replicates old HMM behaviour on Windows, where line breaks were
+  // provided as "\r\n".
+  // 
+  // The assembly parser eats a single '\n' after parsing statements, so
+  // when an error occurs and it eats the statement to move onto the next
+  // one, it ends up taking the next statement with it, because we don't
+  // have '\r' providing a barrier for it.
+  if (isDoubleEOSEmitter) {
+    isDoubleEOSEmitter = false;
+    return AsmToken(AsmToken::EndOfStatement, StringRef(TokStart, 1));
+  }
+
   // This always consumes at least one character.
   int CurChar = getNextChar();
 
@@ -547,6 +572,9 @@ AsmToken AsmLexer::LexToken()
     }
   case '\n': // FALL THROUGH.
   case '\r':
+    // EDIT (Hyper): see beginning of function.
+    if (*CurPtr != '\r' && CurChar == '\n')
+        isDoubleEOSEmitter = true;
     isAtStartOfLine = true;
     return AsmToken(AsmToken::EndOfStatement, StringRef(TokStart, 1));
   case ':': return AsmToken(AsmToken::Colon, StringRef(TokStart, 1));

--- a/CommonLoader/externals/keystone/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/CommonLoader/externals/keystone/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -509,8 +509,9 @@ AsmToken AsmLexer::LexToken()
 
   // EDIT (Hyper): emit two EndOfStatement tokens for single '\n' use.
   // 
-  // This replicates old HMM behaviour on Windows, where line breaks were
-  // provided as "\r\n".
+  // This replicates HMM behaviour on Windows, where line breaks are
+  // provided as "\r\n". This is here as a workaround, in the event that
+  // "\r\n" line breaks are not enforced.
   // 
   // The assembly parser eats a single '\n' after parsing statements, so
   // when an error occurs and it eats the statement to move onto the next

--- a/CommonLoader/externals/keystone/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/CommonLoader/externals/keystone/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -111,6 +111,10 @@ struct ParseStatementInfo {
 
   SmallVectorImpl<AsmRewrite> *AsmRewrites;
 
+  // EDIT (Hyper): store line being parsed for error logging.
+  StringRef Line;
+  SMLoc LineStart;
+
   ParseStatementInfo() : KsError(0), Opcode(~0U), ParseError(false), AsmRewrites(nullptr) {}
   ParseStatementInfo(SmallVectorImpl<AsmRewrite> *rewrites)
     : Opcode(~0), ParseError(false), AsmRewrites(rewrites) {}
@@ -191,7 +195,7 @@ public:
             const MCAsmInfo &MAI);
   ~AsmParser() override;
 
-  size_t Run(bool NoInitialTextSection, uint64_t Address, bool NoFinalize = false) override;
+  size_t Run(bool NoInitialTextSection, uint64_t Address, bool NoFinalize = false, std::vector<ks_err_context>* Errors = nullptr) override;
 
   void addDirectiveHandler(StringRef Directive,
                            ExtensionDirectiveHandler Handler) override {
@@ -666,7 +670,7 @@ const AsmToken &AsmParser::Lex() {
   return *tok;
 }
 
-size_t AsmParser::Run(bool NoInitialTextSection, uint64_t Address, bool NoFinalize)
+size_t AsmParser::Run(bool NoInitialTextSection, uint64_t Address, bool NoFinalize, std::vector<ks_err_context>* Errors)
 {
   // count number of statement
   size_t count = 0;
@@ -709,9 +713,26 @@ size_t AsmParser::Run(bool NoInitialTextSection, uint64_t Address, bool NoFinali
       continue;
     }
 
+    // EDIT (Hyper): implemented optional error results.
+    if (Errors) {
+      unsigned LineBuf = getSourceManager().FindBufferContainingLoc(Info.LineStart);
+      int LineNum = getSourceManager().FindLineNumber(Info.LineStart, LineBuf);
+      const size_t LineChar = (size_t)(Lexer.getLoc().getPointer() - Info.LineStart.getPointer()) + 1;
+
+      // We had an error here.
+      // If reported as 0 (KS_ERR_OK), then best make it unknown.
+      unsigned int ErrNum = Info.KsError ? Info.KsError : -1;
+
+      Errors->push_back(ks_err_context(LineNum, LineChar, ErrNum, Info.Line.str().c_str()));
+    }
+
     //printf(">> 222 error = %u\n", Info.KsError);
-    if (!KsError)
-        KsError = Info.KsError;
+    
+    // EDIT (Hyper): removed this condition to replicate old HMM behaviour.
+    // We need code to still be emitted, even if statements are skipped.
+    // 
+    // if (!KsError)
+    //     KsError = Info.KsError;
 
     // We had an error, validate that one was emitted and recover by skipping to
     // the next line.
@@ -1432,6 +1453,11 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
                                MCAsmParserSemaCallback *SI, uint64_t &Address)
 {
   KsError = 0;
+
+  // EDIT (Hyper): store line being parsed for error logging.
+  Info.Line = Lexer.PeekUntilEndOfLine();
+  Info.LineStart = Lexer.getLoc();
+
   if (Lexer.is(AsmToken::EndOfStatement)) {
     Out.AddBlankLine();
     Lex();

--- a/CommonLoader/include/keystone/keystone.h
+++ b/CommonLoader/include/keystone/keystone.h
@@ -12,6 +12,7 @@ extern "C" {
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 
 #ifdef _MSC_VER     // MSVC compiler
 #pragma warning(disable:4201)
@@ -139,6 +140,21 @@ typedef enum ks_err {
     KS_ERR_ASM_MISSINGFEATURE,
     KS_ERR_ASM_MNEMONICFAIL,
 } ks_err;
+
+struct ks_err_context {
+    size_t line_num{};
+    size_t line_char{};
+    unsigned int err_num{};
+    char line[256]{};
+
+    ks_err_context() {}
+    ks_err_context(size_t line_num, size_t line_char, unsigned int err_num, const char* stat_line = nullptr)
+        : line_num(line_num), line_char(line_char), err_num(err_num) {
+        if (!stat_line)
+            return;
+        strcpy_s(line, sizeof(line), stat_line);
+    }
+};
 
 
 // Resolver callback to provide value for a missing symbol in @symbol.
@@ -306,7 +322,9 @@ int ks_asm(ks_engine *ks,
         const char *string,
         uint64_t address,
         unsigned char **encoding, size_t *encoding_size,
-        size_t *stat_count);
+        size_t *stat_count,
+        ks_err_context **stat_errors = nullptr,
+        size_t *stat_errors_size = nullptr);
 
 
 /*

--- a/CommonLoader/pch.h
+++ b/CommonLoader/pch.h
@@ -3,19 +3,23 @@
 // This also affects IntelliSense performance, including code completion and many code browsing features.
 // However, files listed here are ALL re-compiled if any one of them is updated between builds.
 // Do not add files here that you will be updating frequently as this negates the performance advantage.
-
 #pragma once
+
 #ifndef PCH_H
 #define PCH_H
+
 #define CMN_LOADER_IMPL
+
 #define NOMINMAX
 #include <Windows.h>
+
+#define FMT_HEADER_ONLY
+#include "fmt/core.h"
+
 #include "CommonLoader.h"
 #include "ApplicationStore.h"
 #include "SigScanner.h"
 #include "externals/ini.h"
 #include "externals/xxhash.h"
 
-// add headers that you want to pre-compile here
-
-#endif //PCH_H
+#endif // PCH_H


### PR DESCRIPTION
This PR implements more verbose error reporting for when the assembler or signature scanner fails, including some fixes for backwards compatibility with older HMM codes.

## Assembler Error Reporting
This PR extends Keystone to optionally provide an array of errors reported whilst parsing statements, which are then logged into the console with more helpful information than just a vague error message.

If errors are reported by the assembler, a new message box will appear after code initialisation to warn the user that they can proceed, but the game may be unstable.

<img width="979" height="512" alt="image" src="https://github.com/user-attachments/assets/6eebc03e-bd1b-43ea-8fbd-c04792fde4ae" />

<img width="395" height="198" alt="image" src="https://github.com/user-attachments/assets/ef097340-cce7-4b5d-b72d-8b24e6aa79a5" />

## Signature Scanner Error Reporting
This PR adds new error reporting for when a signature scan fails. It logs the failing signature's pattern and mask to the console so the developer can search for it in their code. DLL mods using the CommonLoader API for signature scanning may also have failing signatures logged to the console.

The error reporting is skipped for signatures that have been cached once and are scanned for again for validation. This is to ensure that we don't display the error message for conflicting codes that write hooks to the same location, as this is valid behaviour, and subsequent scans should return null and be discarded by `WriteAsmHook`.

If errors are reported by the signature scanner, a new message box will appear after code initialisation to warn the user that they can proceed, but the game may be unstable.

<img width="979" height="512" alt="image" src="https://github.com/user-attachments/assets/4e0b7158-1298-42e4-9790-074ace4c0434" />

<img width="395" height="198" alt="image" src="https://github.com/user-attachments/assets/5cc302a1-725e-4317-9b38-e755053ae85b" />

## Fix: Assembler Line Breaks
In HMM versions 7.15-0 and 8.0.0-beta7, the code compiler was changed to enforce `\r\n` line breaks to ensure that the assembler behaved identically between Windows and Linux. With this change also came a new bug with how Keystone parses line breaks.

Each time Keystone parses a statement, it resets the error status to 0 (`KS_ERR_OK`). It doesn't break out of the parsing loop however, so it'll continue to parse statements until the very end where there may not even be an error.

When `\r\n` was enforced in HMM, it was also decided that the assembly string should be ran through [`String.Trim`](https://learn.microsoft.com/en-us/dotnet/api/system.string.trim), which omits leading and trailing whitespace characters (including line breaks).

Because the assembly string handed off to Keystone no longer ended on an empty line, the assembler was able to report that an error had occurred on the last line of some HMM codes. This led to the appearance of some error messages that did not previously present themselves.

This PR changes Keystone to emit two end-of-statement tokens if only `\n` is used, which provides a barrier for statements to still be assembled, even if a previous one failed. This change was made in the event that an assembly string handed to Keystone isn't fixed up to replace all line breaks with `\r\n`.

When Keystone parses a statement, it can eat the end-of-statement token, and if it fails after that, it can result in the next statement also being omitted with it.

For example, with the following x64 assembly:
```asm
push eax                ; invalid
xor  eax, eax           ; valid
mov  [rdi + 0xC0], eax  ; valid
pop  eax                ; invalid
```

This is emitted with `\r\n` as:
```asm
xor eax, eax
mov [rdi + 0xC0], eax
```

And with only `\n` as:
```asm
mov [rdi + 0xC0], eax
```

## Fix: Assembler Comment Syntax
In HMM versions 7.15-0 and 8.0.0-beta7, the code compiler was changed to omit assembly comments starting with a semi-colon, as HMM assembly codes use Intel syntax, and some codes were already using this style of comments.

Unfortunately, Keystone only configured this to be the comment character for NASM syntax, which is incorrect. This resulted in comments in single-line statements being parsed as code, which *is* a feature in Keystone, but it breaks convention.

This PR sets the Keystone comment character for Intel syntax to also be a semi-colon. As such, all codes using single-line statements must now use `\n` as the end-of-statement token, rather than a semi-colon. Omission of semi-colon characters shall be removed from HMM in versions 7.15-1 and 8.0.0-beta8 and is now handled appropriately by Keystone.